### PR TITLE
ブロックの吸収をした後にHPが半分になると例外エラーが出ていたので直した。

### DIFF
--- a/project/game/actor/MapBlock.cpp
+++ b/project/game/actor/MapBlock.cpp
@@ -45,7 +45,7 @@ void MapBlock::Initialize(Object3dCommon* common) {
     // 🚨 注意： GetCurrentScene() の部分は、タイクラーさんの
     // SceneManagerクラスにある「現在のシーンを取得する関数名」に書き換えてください！
     if (BaseScene* currentScene = SceneManager::GetInstance()->GetCurrentScene()) {
-        currentScene->GetObjects().push_back(std::move(laserBeam));
+        currentScene->AddObject(std::move(laserBeam));
     }
 }
 

--- a/project/game/actor/enemy/BossAttack/BossAttack6_Laser.cpp
+++ b/project/game/actor/enemy/BossAttack/BossAttack6_Laser.cpp
@@ -214,7 +214,7 @@ void BossAttack6_Laser::Update(BossCore* boss, float deltaTime) {
                     laser->Initialize(boss->GetCommon());
                     laser->SetModel("Cylinder");
                     laser->SetName("Beam_Cylinder");
-                    if (currentScene) currentScene->GetObjects().push_back(std::move(newLaser));
+                    if (currentScene) currentScene->AddObject(std::move(newLaser));
                 }
 
                 laser->SetBlendMode(BlendMode::kAdd);
@@ -258,7 +258,7 @@ void BossAttack6_Laser::Update(BossCore* boss, float deltaTime) {
                     coreLaser->Initialize(boss->GetCommon());
                     coreLaser->SetModel("Cylinder");
                     coreLaser->SetName("Beam_Core_Cylinder");
-                    if (currentScene) currentScene->GetObjects().push_back(std::move(newCore));
+                    if (currentScene) currentScene->AddObject(std::move(newCore));
                 }
 
                 coreLaser->SetBlendMode(BlendMode::kAdd);

--- a/project/game/actor/enemy/BossAttack/BossAttack8_Final.cpp
+++ b/project/game/actor/enemy/BossAttack/BossAttack8_Final.cpp
@@ -89,7 +89,7 @@ void BossAttack8_Final::Update(BossCore* boss, float deltaTime) {
                 warn->SetEmissive(1.0f); // データ上のデフォルト値
 
                 areaWarnings_.push_back(warn.get());
-                if (currentScene) currentScene->GetObjects().push_back(std::move(warn));
+                if (currentScene) currentScene->AddObject(std::move(warn));
             }
             for (int i = 0; i < 11; ++i) {
                 auto meteor = std::make_unique<Object3d>();
@@ -130,7 +130,7 @@ void BossAttack8_Final::Update(BossCore* boss, float deltaTime) {
                 meteors_.push_back(meteor.get());
 
                 if (currentScene) {
-                    currentScene->GetObjects().push_back(std::move(meteor));
+                    currentScene->AddObject(std::move(meteor));
                 }
             }
         }

--- a/project/game/actor/enemy/BossAttack/BossAttack9_Funnels.cpp
+++ b/project/game/actor/enemy/BossAttack/BossAttack9_Funnels.cpp
@@ -116,7 +116,7 @@ void BossAttack9_Funnels::Update(BossCore* boss, float deltaTime) {
                     laser->Initialize(boss->GetCommon());
                     laser->SetModel("Cylinder");
                     laser->SetName("Beam_Cylinder");
-                    if (currentScene) currentScene->GetObjects().push_back(std::move(newLaser));
+                    if (currentScene) currentScene->AddObject(std::move(newLaser));
                 }
 
                 laser->SetBlendMode(BlendMode::kAdd);
@@ -162,7 +162,7 @@ void BossAttack9_Funnels::Update(BossCore* boss, float deltaTime) {
                     coreLaser->Initialize(boss->GetCommon());
                     coreLaser->SetModel("Cylinder");
                     coreLaser->SetName("Beam_Core_Cylinder");
-                    if (currentScene) currentScene->GetObjects().push_back(std::move(newCore));
+                    if (currentScene) currentScene->AddObject(std::move(newCore));
                 }
 
                 coreLaser->SetBlendMode(BlendMode::kAdd);

--- a/project/game/actor/enemy/BossCore.cpp
+++ b/project/game/actor/enemy/BossCore.cpp
@@ -1435,7 +1435,7 @@ void BossCore::TakeBodyDamage(float damage) {
 
                     // 登録
                     CollisionManager::GetInstance()->AddObject(mapBlock.get());
-                    currentScene->GetObjects().push_back(std::move(mapBlock));
+                    currentScene->AddObject(std::move(mapBlock));
                 }
             }
         }


### PR DESCRIPTION
<AI判定>

原因
この例外エラー <begin>$L1->_Mypair.**_Myval2** が nullptr でした は、C++の標準ライブラリにおけるイテレータ無効化（Iterator Invalidation） が原因です。

具体的には、HPが50%になった瞬間に BossCore::TakeBodyDamage が呼ばれ、その中でマップ上にばらまくための MapBlock を20個生成し、以下のようにシーンのオブジェクトリストに直接 push_back をしていました。

cpp
// 修正前のBossCore.cpp
currentScene->GetObjects().push_back(std::move(mapBlock)); 一方で、BossCore::Update 自体は GamePlayScene::Update （または ObjectManager::Update）の中で、GetObjects() のリストを 範囲ベースforループ（range-based for loop） でイテレーションしている最中に呼び出されています。 ループで走査している最中の std::vector に対して直接 push_back を行うと、ベクターの内部容量が足りなくなった際にメモリの再確保が行われ、現在ループ処理で使っていた「イテレータ（現在位置のポインタ）」が破壊（無効化）されてしまいます。その結果、次のループに回ろうとした瞬間に無効なメモリアドレスを参照してしまい、アクセス違反のエラーが発生していました。

修正内容
直接 push_back するのではなく、AddObject 関数を使用するように変更しました。 AddObject は ObjectManager 内部の pendingObjects_（追加待ちリスト）にオブジェクトを一時保存し、次のフレームの最初に安全にメインリストにマージする仕組みになっているため、ループ中の再確保によるクラッシュを完全に防ぐことができます。

以下のファイルについて、該当箇所（GetObjects().push_back）を AddObject に置き換える修正を行いました：

game\actor\enemy\BossCore.cpp （HP半減時のブロック生成）
game\actor\MapBlock.cpp （レーザーの初期化時）
game\actor\enemy\BossAttack\BossAttack6_Laser.cpp （レーザー攻撃時） game\actor\enemy\BossAttack\BossAttack8_Final.cpp （メテオ攻撃時） game\actor\enemy\BossAttack\BossAttack9_Funnels.cpp （ファンネル攻撃時） これでデバッグコマンドでHPを半分にしても、安全にフェーズ移行が行われクラッシュしなくなります。Visual Studio側でビルドして動作をご確認ください！