### PR TITLE
体力半分演出時にプレイヤーが動けてしまうバグの修正　ボムをボスが出してる時に攻撃するとボスの所でボムが爆発して大ダメージ与えるバグの修正　…

### DIFF
--- a/project/engine/graphics/3d/light/LightManager.cpp
+++ b/project/engine/graphics/3d/light/LightManager.cpp
@@ -87,7 +87,7 @@ void LightManager::Update() {
 
                 // 太陽目線のビュー行列と正投影行列を計算（Math::を付けて静的関数として呼び出し）
                 Matrix4x4 lightView = Math::MakeLookAtMatrix(lightPos, target, up);
-                Matrix4x4 lightProj = Math::MakeOrthographicMatrix(80.0f, 80.0f, 1.0f, 400.0f);
+                Matrix4x4 lightProj = Math::MakeOrthographicMatrix(120.0f, 120.0f, 1.0f, 400.0f);
 
                 // 計算結果を構造体に保存（この後すぐ下の行でGPUへ送られます）
                 directionalLightData_.lightViewProj = Math::Multiply(lightView, lightProj);

--- a/project/game/actor/enemy/BossAttack/BossAttack8_Final.cpp
+++ b/project/game/actor/enemy/BossAttack/BossAttack8_Final.cpp
@@ -208,7 +208,8 @@ void BossAttack8_Final::Update(BossCore* boss, float deltaTime) {
             
             static Math math;
             Vector3 uvScale = { 3.0f, 20.0f, 1.0f };
-            Vector3 uvTranslate = { 0.0f, animTimer_ * 10.0f, 0.0f };
+            constexpr float kRushWarningUvSpeed = 2.0f;
+            Vector3 uvTranslate = { 0.0f, animTimer_ * kRushWarningUvSpeed, 0.0f };
             warning->SetUVTransform(math.MakeAffineMatrix(uvScale, {0,0,0}, uvTranslate));
             warning->UpdateWorldMatrix();
         }

--- a/project/game/actor/enemy/BossCore.cpp
+++ b/project/game/actor/enemy/BossCore.cpp
@@ -286,6 +286,14 @@ void BossCore::Update(float deltaTime) {
     if (isHpHalfEventActive_) {
         hpHalfEffectTimer_ += deltaTime; // 演出タイマーは実時間
 
+        if (target_) {
+            if (auto player = dynamic_cast<Player*>(target_)) {
+                player->SetControlLock(true);
+                player->SetIsPhysicsActive(false);
+                player->SetVelocity({ 0.0f, 0.0f, 0.0f });
+            }
+        }
+
         // カメラ演出の終了を監視し、終わった瞬間に向きをボスに合わせる
         if (!isPlayerRotated_) {
             if (Camera* camera = CameraManager::GetInstance()->GetMainCamera()) {
@@ -544,7 +552,12 @@ void BossCore::Update(float deltaTime) {
 
             if (target_) {
                 if (auto player = dynamic_cast<Player*>(target_)) {
-                    player->SetIsControlActive(true);
+                    player->SetControlLock(false);
+                    player->SetVelocity({ 0.0f, 0.0f, 0.0f });
+                    player->SetIsPhysicsActive(true);
+                    if (!player->IsDeathSequenceActive()) {
+                        player->SetIsControlActive(true);
+                    }
                 }
             }
             SetColor(greenColor_);

--- a/project/game/actor/enemy/EnemyBomb.cpp
+++ b/project/game/actor/enemy/EnemyBomb.cpp
@@ -22,6 +22,7 @@ void EnemyBomb::Initialize(Object3dCommon* common, const std::string& modelName)
     igniteTimer_ = 0.0f;
     hitCount_ = 0;
     isBlownAway_ = false;
+    hasLandedOnce_ = false;
     shakeTimer_ = 0.0f;
     stunTimer_ = 0.0f;
     lastShakeOffset_ = { 0,0,0 };
@@ -42,7 +43,7 @@ void EnemyBomb::Initialize(Object3dCommon* common, const std::string& modelName)
     SetColliderConfig(colConfig);
 
     // kGroundは追加しない（壁や柱をすり抜けてスムーズに転がり、接地はY座標で制御する）
-    SetCollisionMask(kPlayer | kAttributePlayerBullet | kPlayerAttack | kEnemy);
+    SetCollisionMask(kPlayer | kAttributePlayerBullet | kEnemy);
 
 
     // JSONファイルから攻撃パラメータを読み込んで攻撃力を設定
@@ -112,6 +113,21 @@ void EnemyBomb::SetVisualPartsVisible(bool visible) {
     }
 }
 
+void EnemyBomb::EnableReflectAfterLanding() {
+    if (hasLandedOnce_) {
+        return;
+    }
+
+    hasLandedOnce_ = true;
+    if (!isBlownAway_ && state_ != State::Exploded) {
+        SetCollisionMask(GetCollisionMask() | kPlayerAttack);
+    }
+}
+
+bool EnemyBomb::CanReflectByPlayer() const {
+    return hasLandedOnce_ && !isBlownAway_ && state_ != State::Exploded;
+}
+
 void EnemyBomb::Update(float deltaTime) {
     if (!GetTransform()) {
         BaseEnemy::Update(deltaTime);
@@ -140,6 +156,8 @@ void EnemyBomb::Update(float deltaTime) {
         bool onGround = (GetTransform()->translate.y <= 1.01f);
 
         if (onGround) {
+            EnableReflectAfterLanding();
+
             // 接地：Y座標を 1.0f (球体の半径) に強制吸着し、落下速度をゼロにする
             GetTransform()->translate.y = 1.0f;
             if (velocity_.y < 0.0f) {
@@ -268,6 +286,10 @@ void EnemyBomb::Update(float deltaTime) {
 
     BaseEnemy::Update(deltaTime);
 
+    if (!hasLandedOnce_ && GetTransform()->translate.y <= 1.01f) {
+        EnableReflectAfterLanding();
+    }
+
     // 点火待機中（吹き飛ばされていない）ならば、重力による毎フレームの沈み込みをシャットアウトし、
     // 拡大したスケールに応じて球体の底面が地面（Y=0.0f）に完全に接地し続けるように補正
     if (!isBlownAway_ && state_ == State::Ignited) {
@@ -366,6 +388,10 @@ bool EnemyBomb::OnCollision(Object3d* other) {
 
     // 2. プレイヤーの攻撃を受けた場合（スライム同様に跳ね返せる）
     if (attribute & kPlayerAttack) {
+        if (!CanReflectByPlayer()) {
+            return true;
+        }
+
         if (damageCooldownTimer_ <= 0.0f) {
             if (EffectObject3d* effect = dynamic_cast<EffectObject3d*>(other)) {
                 effect->AddHitObject(this);

--- a/project/game/actor/enemy/EnemyBomb.h
+++ b/project/game/actor/enemy/EnemyBomb.h
@@ -15,6 +15,8 @@ private:
     void SetVisualPartsColor(const Vector4& color);
     void SetVisualPartsVisible(bool visible);
     void UpdateColorByHitCount();
+    void EnableReflectAfterLanding();
+    bool CanReflectByPlayer() const;
 
     // ボム兵の状態
     enum class State {
@@ -37,6 +39,7 @@ private:
     // 吹き飛ばし・跳ね返し用
     int hitCount_ = 0;
     bool isBlownAway_ = false;
+    bool hasLandedOnce_ = false;
     float shakeTimer_ = 0.0f;
     float stunTimer_ = 0.0f;
     Vector3 lastShakeOffset_ = { 0,0,0 };

--- a/project/game/actor/enemy/boss_core/BossCoreCombat.cpp
+++ b/project/game/actor/enemy/boss_core/BossCoreCombat.cpp
@@ -178,7 +178,9 @@ void BossCore::TakeBodyDamage(float damage) {
 
         if (target_) {
             if (auto player = dynamic_cast<Player*>(target_)) {
+                player->SetControlLock(true);
                 player->SetIsControlActive(false);
+                player->SetIsPhysicsActive(false);
                 player->SetVelocity({ 0.0f, 0.0f, 0.0f });
                 player->SetTranslate({ 0.0f, 1.231f, -60.0f });
                 player->UpdateWorldMatrix();

--- a/project/game/actor/enemy/boss_core/BossCoreDeath.cpp
+++ b/project/game/actor/enemy/boss_core/BossCoreDeath.cpp
@@ -1,5 +1,25 @@
 #include "BossCoreShared.h"
 
+namespace {
+constexpr Vector4 kBossBreakCoreColor = { 0.0f, 0.59459448f, 1.0f, 1.0f };
+
+void ApplyBossBreakCoreVisual(Object3d* object, float emissive = 2.0f) {
+    if (!object) {
+        return;
+    }
+
+    object->SetColor(kBossBreakCoreColor);
+    object->SetMaterialType(2);
+    object->SetSelectedLighting(2);
+    object->SetEmissive(emissive);
+    object->SetMetallic(0.0f);
+    object->SetRoughness(0.5f);
+    object->SetEnableNormalMap(false);
+    object->SetEnableEnvMap(false);
+    object->SetEnvIntensity(0.0f);
+}
+}
+
 void BossCore::StartDeathSequence() {
     if (deathPhase_ != 0) return; // 既に死亡処理中なら何もしない
 
@@ -7,6 +27,9 @@ void BossCore::StartDeathSequence() {
 
     deathPhase_ = 1;         // フェーズ1（無音で静止）
     sequenceTimer_ = 1.0f;   // 1秒間待機
+
+    ApplyBossBreakCoreVisual(this);
+    defaultColor_ = kBossBreakCoreColor;
 
     DebugConsole::GetInstance()->AddLog("[撃破] ボス沈黙…！！");
 
@@ -83,13 +106,7 @@ void BossCore::ActuallySpawnShards() {
             pieceObj->Initialize(common_);
             pieceObj->SetStatic(true);
             pieceObj->SetModel("enemy_core_shards/enemy_core" + std::to_string(i + 1));
-            pieceObj->SetColor({ 0.0f, 0.5946f, 1.0f, 1.0f });
-            pieceObj->SetMaterialType(2);
-            pieceObj->SetEmissive(2.0f);
-            pieceObj->SetMetallic(0.0f);
-            pieceObj->SetRoughness(0.5f);
-            pieceObj->SetEnableEnvMap(true);
-            pieceObj->SetEnvIntensity(1.035f);
+            ApplyBossBreakCoreVisual(pieceObj.get());
             pieceObj->SetScale({ 1.0f, 1.0f, 1.0f });
             pieceObj->SetCollisionAttribute(0);
 
@@ -133,7 +150,7 @@ void BossCore::BreakCore() {
             };
 
             // 発光を元に戻す
-            piece.obj->SetEmissive(1.0f);
+            ApplyBossBreakCoreVisual(piece.obj, 1.0f);
         }
     }
 }

--- a/project/game/actor/player/Player.h
+++ b/project/game/actor/player/Player.h
@@ -89,7 +89,14 @@ public:
     // --- 状態フラグ ---
     void SetLockOn(bool isLockingOn) { isLockingOn_ = isLockingOn; }
     bool IsLockingOn() const { return isLockingOn_; }
-    void SetIsControlActive(bool isActive) { isControlActive_ = isActive; }
+    void SetIsControlActive(bool isActive) { isControlActive_ = isControlLocked_ ? false : isActive; }
+    void SetControlLock(bool isLocked)
+    {
+        isControlLocked_ = isLocked;
+        if (isLocked) {
+            isControlActive_ = false;
+        }
+    }
     void SetIsPhysicsActive(bool active) { isPhysicsActive_ = active; }
     bool GetIsControlActive() const { return isControlActive_; }
     bool IsPhysicsActive() const { return isPhysicsActive_; }
@@ -165,6 +172,7 @@ private:
     bool isLockingOn_ = false;       // 敵をロックオンしているか
     bool isControlActive_ = true;    // 入力を受け付ける状態か（デモシーン等で制限用）
     bool isPhysicsActive_ = true;    // 物理演算・移動計算を行うか（座標固定用）
+    bool isControlLocked_ = false;
 
     // コンボ待ちフラグ：Attack1 終了後に次のクリックで Attack2 を出すために使う
     bool pendingAttack2_ = false;


### PR DESCRIPTION
…・最後ボスが割れる演出の時の色が統一されていないので直した